### PR TITLE
Added flux_tube plot

### DIFF
--- a/qsc/qsc.py
+++ b/qsc/qsc.py
@@ -28,7 +28,7 @@ class Qsc():
     from .calculate_r3 import calculate_r3
     from .mercier import mercier
     from .r_singularity import calculate_r_singularity
-    from .plot import plot, plot_boundary, get_boundary, B_fieldline, B_contour, plot_axis
+    from .plot import plot, plot_boundary, get_boundary, B_fieldline, B_contour, plot_axis, flux_tube
     from .Frenet_to_cylindrical import Frenet_to_cylindrical
     from .to_vmec import to_vmec
     from .util import B_mag

--- a/qsc/tests/test_plot.py
+++ b/qsc/tests/test_plot.py
@@ -81,7 +81,7 @@ class PlotTests(unittest.TestCase):
 
     def test_flux_tube(self):
         stel = Qsc.from_paper(4, order='r2')
-        stel.flux_tube()
+        stel.flux_tube(show=False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/qsc/tests/test_plot.py
+++ b/qsc/tests/test_plot.py
@@ -79,5 +79,9 @@ class PlotTests(unittest.TestCase):
         stel.B_contour(show=False)
         plt.close()
 
+    def test_flux_tube(self):
+        stel = Qsc.from_paper(4, order='r2')
+        stel.flux_tube()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the capability to pyQSC to plot flux tubes. This is useful to show where the flux tube is located in a particular geometry, which is relevant when running simulations such as gyrokinetic GS2 or GX.