### PR TITLE
PR: Get a near-axis configuration from BOOZ_XFORM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: apt-get stuff needed for libstell and vmec
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4
+        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4 libfftw3-dev libboost-all-dev libopenblas-dev
 
     - uses: actions/checkout@v2
       # If we want submodules downloaded, uncomment the next 2 lines:
@@ -51,6 +51,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel numpy mpi4py scipy matplotlib
+
+    - name: Install booz_xform
+      run: pip install -v git+https://github.com/hiddenSymmetries/booz_xform
     
     - name: env after adding python
       run: env

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ threed*
 wout*
 mercier*
 parvmec*
+xvmec2000
+timings.txt

--- a/qsc/qsc.py
+++ b/qsc/qsc.py
@@ -372,7 +372,7 @@ class Qsc():
         return np.max((0, self.min_R0_threshold - self.min_R0)) ** 2
         
     @classmethod
-    def from_vmec(cls, vmec_file, booz_xform_file, max_s_for_fit = 0.5, N_phi = 200):
+    def from_boozxform(cls, booz_xform_file, max_s_for_fit = 0.5, N_phi = 200, vmec_file=None, rc=[], rs=[], zc=[], zs=[]):
         """
         Load a configuration from a VMEC and a BOOZ_XFORM output files
         """
@@ -389,14 +389,25 @@ class Qsc():
         iotaVMECt=f.variables['iota_b'][()][1]
         f.close()
 
-        # Read properties of VMEC output file
-        f = netcdf.netcdf_file(vmec_file,'r',mmap=False)
-        rc = f.variables['raxis_cc'][()]
-        zs = f.variables['zaxis_cs'][()]
-        f.close()
+        if vmec_file!=None:
+            # Read axis-shape from VMEC output file
+            f = netcdf.netcdf_file(vmec_file,'r',mmap=False)
+            rc = f.variables['raxis_cc'][()]
+            rs = f.variables['raxis_cs'][()]
+            zc = f.variables['zaxis_cc'][()]
+            zs = f.variables['zaxis_cs'][()]
+            f.close()
+        elif rc!=None:
+            # Read axis-shape from specified rc
+            rc=rc
+            rs=rs
+            zc=zc
+            zs=zs
+        else:
+            raise Exception("Axis shape not specified")
 
         # Calculate nNormal
-        stel = Qsc(rc=rc,zs=zs)
+        stel = Qsc(rc=rc,rs=rs,zc=zc,zs=zs)
         nNormal = stel.iota - stel.iotaN
 
         # Prepare coordinates for fit

--- a/qsc/qsc.py
+++ b/qsc/qsc.py
@@ -371,3 +371,100 @@ class Qsc():
         """
         return np.max((0, self.min_R0_threshold - self.min_R0)) ** 2
         
+    @classmethod
+    def from_vmec(cls, vmec_file, booz_xform_file, max_s_for_fit = 0.5, N_phi = 200):
+        """
+        Load a configuration from a VMEC and a BOOZ_XFORM output files
+        """
+        # Read properties of BOOZ_XFORM output file
+        f = netcdf.netcdf_file(booz_xform_file,'r',mmap=False)
+        bmnc = f.variables['bmnc_b'][()]
+        ixm = f.variables['ixm_b'][()]
+        ixn = f.variables['ixn_b'][()]
+        jlist = f.variables['jlist'][()]
+        ns = f.variables['ns_b'][()]
+        nfp = f.variables['nfp_b'][()]
+        Psi = f.variables['phi_b'][()]
+        Psi_a = np.abs(Psi[-1])
+        iotaVMECt=f.variables['iota_b'][()][1]
+        f.close()
+
+        # Read properties of VMEC output file
+        f = netcdf.netcdf_file(vmec_file,'r',mmap=False)
+        rc = f.variables['raxis_cc'][()]
+        zs = f.variables['zaxis_cs'][()]
+        f.close()
+
+        # Calculate nNormal
+        stel = Qsc(rc=rc,zs=zs)
+        nNormal = stel.iota - stel.iotaN
+
+        # Prepare coordinates for fit
+        s_full = np.linspace(0,1,ns)
+        ds = s_full[1] - s_full[0]
+        #s_half = s_full[1:] - 0.5*ds
+        s_half = s_full[jlist-1] - 0.5*ds
+        mask = s_half < max_s_for_fit
+        s_fine = np.linspace(0,1,400)
+        sqrts_fine = s_fine
+        phi = np.linspace(0,2*np.pi / nfp, N_phi)
+        B0  = np.zeros(N_phi)
+        B1s = np.zeros(N_phi)
+        B1c = np.zeros(N_phi)
+        B20 = np.zeros(N_phi)
+        B2s = np.zeros(N_phi)
+        B2c = np.zeros(N_phi)
+
+        # Perform fit
+        for jmn in range(len(ixm)):
+            m = ixm[jmn]
+            n = ixn[jmn] / nfp
+            if m>2:
+                continue
+            if m==0:
+                # For m=0, fit a polynomial in s (not sqrt(s)) that does not need to go through the origin.
+                degree = 4
+                p = np.polyfit(s_half[mask], bmnc[mask,jmn], degree)
+                B0 += p[-1] * np.cos(n*nfp*phi)
+                B20 += p[-2] * np.cos(n*nfp*phi)
+            if m==1:
+                # For m=1, fit a polynomial in sqrt(s) to an odd function
+                x1 = np.sqrt(s_half[mask])
+                y1 = bmnc[mask,jmn]
+                x2 = np.concatenate((-x1,x1))
+                y2 = np.concatenate((-y1,y1))
+                degree = 5
+                p = np.polyfit(x2,y2, degree)
+                B1c += p[-2] * (np.sin(n*nfp*phi) * np.sin(nNormal*phi) + np.cos(n*nfp*phi) * np.cos(nNormal*phi))
+                B1s += p[-2] * (np.sin(n*nfp*phi) * np.cos(nNormal*phi) - np.cos(n*nfp*phi) * np.sin(nNormal*phi))
+                #B1c += p[-2] * np.cos(n*nfp*phi)
+                #B1s += p[-2] * np.sin(n*nfp*phi)
+            if m==2:
+                # For m=2, fit a polynomial in s (not sqrt(s)) that does need to go through the origin.
+                x1 = s_half[mask]
+                y1 = bmnc[mask,jmn]
+                x2=x1
+                y2=y1
+                degree = 4
+                p = np.polyfit(x2,y2, degree)
+                B2c += p[-2] * (np.sin(n*nfp*phi) * np.sin(nNormal*phi) + np.cos(n*nfp*phi) * np.cos(nNormal*phi))
+                B2s += p[-2] * (np.sin(n*nfp*phi) * np.cos(nNormal*phi) - np.cos(n*nfp*phi) * np.sin(nNormal*phi))
+                #B2c += p[-2] * np.cos(n*nfp*phi)
+                #B2s += p[-2] * np.sin(n*nfp*phi)
+
+        # Convert expansion in sqrt(s) to an expansion in r
+        BBar = np.mean(B0)
+        sqrt_s_over_r = np.sqrt(np.pi * BBar / Psi_a)
+        B1s *= sqrt_s_over_r
+        B1c *= sqrt_s_over_r
+        B20 *= sqrt_s_over_r*sqrt_s_over_r
+        B2c *= sqrt_s_over_r*sqrt_s_over_r
+        B2s *= sqrt_s_over_r*sqrt_s_over_r
+        eta_bar = np.mean(B1c) / BBar
+
+        q = cls(rc=rc,zs=zs,etabar=eta_bar,nphi=N_phi,nfp=nfp,B0=BBar)
+
+        # Return results
+        # return [BBar,eta_bar,B0,B1s,B1c,B20,B2c,B2s,phi,Psi_a,iotaVMECt,nfp,stel]
+
+        return q

--- a/qsc/tests/test_from_boozxform.py
+++ b/qsc/tests/test_from_boozxform.py
@@ -36,7 +36,7 @@ def compare_from_boozxform(name, r=0.005, nphi=151):
     # Run BOOZ_XFORM
     b1 = bx.Booz_xform()
     b1.read_wout(woutFile)
-    b1.compute_surfs = [5,10,15,20,30,40,50,60,80,100]
+    b1.compute_surfs = [5,10,15,20,25,35,45,60,75,90]
     b1.mboz = 120
     b1.nboz = 40
     b1.run()

--- a/qsc/tests/test_from_boozxform.py
+++ b/qsc/tests/test_from_boozxform.py
@@ -14,48 +14,63 @@ import booz_xform as bx
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def compare_from_boozxform(name, r=0.005, nphi=151):
+def compare_from_boozxform(name, r=0.008, nphi=151):
     # Add the directory of this file to the specified filename:
     inputFile="input."+str(name).replace(" ","")
     abs_filename = os.path.join(os.path.dirname(__file__), inputFile)
+    woutFile="wout_"+str(name).replace(" ","")+".nc"
+    boozFile="boozmn_"+str(name).replace(" ","")+".nc"
     # Run pyQsc and create a VMEC input file
     logger.info('Creating pyQSC configuration')
-    order = 'r2' if name[1] == '2' else 'r1'
-    py = Qsc.from_paper(name, nphi=nphi, order=order)
+    py = Qsc.from_paper(name, nphi=nphi)
     logger.info('Outputing to VMEC')
-    py.to_vmec(inputFile,r)
+
+    py.to_vmec(inputFile,r,params={"ftol_array": [2e-17,5e-17,3e-16,5e-16], "ns_array": [16,49,101,151], "niter_array": [2000,2000,2000,2000]})
+
     # Run VMEC
     fcomm = MPI.COMM_WORLD.py2f()
     logger.info("Calling runvmec. comm={}".format(fcomm))
     ictrl=np.array([15,0,0,0,0], dtype=np.int32)
     vmec.runvmec(ictrl, inputFile, True, fcomm, '')
-    woutFile="wout_"+str(name).replace(" ","")+".nc"
     # Check that VMEC converged
     assert ictrl[1] == 11
     vmec.cleanup(True)
+
+    # Run VMEC locally
+    # bashCommand = "./xvmec2000 input."+str(name).replace(" ","")
+    # from subprocess import run
+    # run(bashCommand.split())
+
     # Run BOOZ_XFORM
     b1 = bx.Booz_xform()
+
     b1.read_wout(woutFile)
-    b1.compute_surfs = [5,10,15,20,25,35,45,60,75,90]
+    b1.compute_surfs = [0,5,10,15,20,25,30,40,50,60,75,90,105,125,149]
     b1.mboz = 120
     b1.nboz = 40
     b1.run()
-    boozFile="boozmn_"+str(name).replace(" ","")+".nc"
     b1.write_boozmn(boozFile)
+
+    # Read local BOOZ_XFORM file
+    # b1.read_boozmn(boozFile)
     # Check results
-    stel = Qsc.from_boozxform(boozFile, vmec_file=woutFile)
+    stel = Qsc.from_boozxform(boozFile, vmec_file=woutFile, order=py.order, sigma0=py.sigma0, I2=py.I2)
     logger.info('Initial iota on axis = '+str(py.iota)+'for case '+name)
-    logger.info('Final iota on axis = '+str(stel.iota)+'for case '+name)
+    logger.info('Final   iota on axis = '+str(stel.iota)+'for case '+name)
     assert np.isclose(py.iota,stel.iota,rtol=1e-2)
     logger.info('Initial B0 = '+str(py.B0)+'for case '+name)
-    logger.info('Final B0 = '+str(stel.B0)+'for case '+name)
+    logger.info('Final   B0 = '+str(stel.B0)+'for case '+name)
     assert np.isclose(py.B0,stel.B0,rtol=1e-2)
-    logger.info('Initial B1c on axis = '+str(py.B1c)+'for case '+name)
-    logger.info('Final B1c on axis = '+str(stel.B1c)+'for case '+name)
-    assert np.isclose(py.B1c,stel.B1c,rtol=1e-2)
-    logger.info('Initial B2c on axis = '+str(py.B2c)+'for case '+name)
-    logger.info('Final B2c on axis = '+str(stel.B2c)+'for case '+name)
-    assert np.isclose(py.B2c,stel.B2c,rtol=1e-2)
+    logger.info('Initial etabar = '+str(py.etabar)+'for case '+name)
+    logger.info('Final   etabar = '+str(stel.etabar)+'for case '+name)
+    assert np.isclose(py.etabar,stel.etabar,rtol=2e-2)
+    if stel.order != 'r1':
+        logger.info('Initial B2c = '+str(py.B2c)+'for case '+name)
+        logger.info('Final   B2c = '+str(stel.B2c)+'for case '+name)
+        logger.info('Initial B2s = '+str(py.B2s)+'for case '+name)
+        logger.info('Final   B2s = '+str(stel.B2s)+'for case '+name)
+        assert np.isclose(py.B2c,stel.B2c,rtol=2e-2,atol=5e-3)
+        assert np.isclose(py.B2s,stel.B2s,rtol=1e-3,atol=1e-3)
 
 class FromBoozxformTests(unittest.TestCase):
 
@@ -65,12 +80,12 @@ class FromBoozxformTests(unittest.TestCase):
         logger.setLevel(1)
         self.cases=["r1 section 5.1","r1 section 5.2","r1 section 5.3",\
                     "r2 section 5.1","r2 section 5.2","r2 section 5.3","r2 section 5.4","r2 section 5.5"]
-        # self.cases=["r1 section 5.1"]
 
     def test_from_boozxform(self):
         """
         Verify that the we can read the Booz_Xform and VMEC files and
-        that iota on axis match the predicted values.
+        that iota on axis match the predicted values when using the to_vmec
+        and from_boozxform functions one after the other.
         """
         for case in self.cases:
             logger.info('Going through case '+case)

--- a/qsc/tests/test_from_boozxform.py
+++ b/qsc/tests/test_from_boozxform.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+from qsc.util import to_Fourier
+import unittest
+import os
+from scipy.io import netcdf
+import numpy as np
+import logging
+from qsc.qsc import Qsc
+from mpi4py import MPI
+import vmec
+import booz_xform as bx
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def compare_from_boozxform(name, r=0.005, nphi=151):
+    # Add the directory of this file to the specified filename:
+    inputFile="input."+str(name).replace(" ","")
+    abs_filename = os.path.join(os.path.dirname(__file__), inputFile)
+    # Run pyQsc and create a VMEC input file
+    logger.info('Creating pyQSC configuration')
+    order = 'r2' if name[1] == '2' else 'r1'
+    py = Qsc.from_paper(name, nphi=nphi, order=order)
+    logger.info('Outputing to VMEC')
+    py.to_vmec(inputFile,r)
+    # Run VMEC
+    fcomm = MPI.COMM_WORLD.py2f()
+    logger.info("Calling runvmec. comm={}".format(fcomm))
+    ictrl=np.array([15,0,0,0,0], dtype=np.int32)
+    vmec.runvmec(ictrl, inputFile, True, fcomm, '')
+    woutFile="wout_"+str(name).replace(" ","")+".nc"
+    # Check that VMEC converged
+    assert ictrl[1] == 11
+    vmec.cleanup(True)
+    # Run BOOZ_XFORM
+    b1 = bx.Booz_xform()
+    b1.read_wout(woutFile)
+    b1.compute_surfs = [5,10,15,20,30,40,50,60,80,100]
+    b1.mboz = 120
+    b1.nboz = 40
+    b1.run()
+    boozFile="boozmn_"+str(name).replace(" ","")+".nc"
+    b1.write_boozmn(boozFile)
+    # Check results
+    stel = Qsc.from_boozxform(boozFile, vmec_file=woutFile)
+    logger.info('Initial iota on axis = '+str(py.iota)+'for case '+name)
+    logger.info('Final iota on axis = '+str(stel.iota)+'for case '+name)
+    assert np.isclose(py.iota,stel.iota,rtol=1e-2)
+    logger.info('Initial B0 = '+str(py.B0)+'for case '+name)
+    logger.info('Final B0 = '+str(stel.B0)+'for case '+name)
+    assert np.isclose(py.B0,stel.B0,rtol=1e-2)
+    logger.info('Initial B1c on axis = '+str(py.B1c)+'for case '+name)
+    logger.info('Final B1c on axis = '+str(stel.B1c)+'for case '+name)
+    assert np.isclose(py.B1c,stel.B1c,rtol=1e-2)
+    logger.info('Initial B2c on axis = '+str(py.B2c)+'for case '+name)
+    logger.info('Final B2c on axis = '+str(stel.B2c)+'for case '+name)
+    assert np.isclose(py.B2c,stel.B2c,rtol=1e-2)
+
+class FromBoozxformTests(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(FromBoozxformTests, self).__init__(*args, **kwargs)
+        logger = logging.getLogger('qsc.qsc')
+        logger.setLevel(1)
+        self.cases=["r1 section 5.1","r1 section 5.2","r1 section 5.3",\
+                    "r2 section 5.1","r2 section 5.2","r2 section 5.3","r2 section 5.4","r2 section 5.5"]
+        # self.cases=["r1 section 5.1"]
+
+    def test_from_boozxform(self):
+        """
+        Verify that the we can read the Booz_Xform and VMEC files and
+        that iota on axis match the predicted values.
+        """
+        for case in self.cases:
+            logger.info('Going through case '+case)
+            compare_from_boozxform(case)

--- a/qsc/tests/test_to_vmec.py
+++ b/qsc/tests/test_to_vmec.py
@@ -24,8 +24,7 @@ def compare_to_vmec(name, r=0.005, nphi=151):
     abs_filename = os.path.join(os.path.dirname(__file__), inputFile)
     # Run pyQsc and create a VMEC input file
     logger.info('Creating pyQSC configuration')
-    order = 'r2' if name[1] == '2' else 'r1'
-    py = Qsc.from_paper(name, nphi=nphi, order=order)
+    py = Qsc.from_paper(name, nphi=nphi)
     logger.info('Outputing to VMEC')
     py.to_vmec(inputFile,r)
     # Run VMEC


### PR DESCRIPTION
This PR adds the capability to pyQSC to get the best fit near-axis configuration from a BOOZ_XFORM output file. However, the user needs to specify either a VMEC file or an axis shape in order to get every input parameter needed to create a Qsc instance. What is needed for it to be complete:

- The test with r2 section 5.4 is failing
- How to obtain I2 from VMEC?
- Is it possible to get more parameters from BOOZ_XFORM so the user doesn't need VMEC for so many things?
- The tolerance for B2c needs to be set to more than atol=1e-3. Is it still reliable?
- Estimate B3 so that we are able to get B3c1 for a shear calculation.

