### PR TITLE
ag/gradgrad b fix

### DIFF
--- a/qsc/grad_B_tensor.py
+++ b/qsc/grad_B_tensor.py
@@ -1311,7 +1311,14 @@ def grad_grad_B_tensor_cylindrical(self):
     vector B=(B_R,B_phi,B_Z) at every point along the axis (hence with nphi points)
     where R, phi and Z are the standard cylindrical coordinates.
     '''
-    return np.transpose(self.grad_grad_B,(1,2,3,0))
+    n = self.normal_cylindrical.transpose()
+    b = self.binormal_cylindrical.transpose()
+    t = self.tangent_cylindrical.transpose()
+    Q = np.concatenate((n[:, None, :], b[:, None, :], t[:, None, :]), axis=1)
+
+    ggB_frenet = np.transpose(self.grad_grad_B,(1,2,3,0))
+    ggB_cyl = np.einsum('piz,qjz,rkz,pqrz->ijkz', Q, Q, Q, ggB_frenet)
+    return ggB_cyl
 
 def grad_grad_B_tensor_cartesian(self):
     '''

--- a/qsc/grad_B_tensor.py
+++ b/qsc/grad_B_tensor.py
@@ -1306,92 +1306,41 @@ def grad_B_tensor_cartesian(self):
     return grad_B_vector_cartesian
 
 def grad_grad_B_tensor_cylindrical(self):
-    '''
-    Function to calculate the gradient of of the gradient the magnetic field
-    vector B=(B_R,B_phi,B_Z) at every point along the axis (hence with nphi points)
-    where R, phi and Z are the standard cylindrical coordinates.
-    '''
-    n = self.normal_cylindrical.transpose()
-    b = self.binormal_cylindrical.transpose()
-    t = self.tangent_cylindrical.transpose()
-    Q = np.concatenate((n[:, None, :], b[:, None, :], t[:, None, :]), axis=1)
-
-    ggB_frenet = np.transpose(self.grad_grad_B,(1,2,3,0))
-    ggB_cyl = np.einsum('piz,qjz,rkz,pqrz->ijkz', Q, Q, Q, ggB_frenet)
-    return ggB_cyl
+     '''
+     Function to calculate the gradient of of the gradient the magnetic field
+     vector B=(B_R,B_phi,B_Z) at every point along the axis (hence with nphi points)
+     where R, phi and Z are the standard cylindrical coordinates.
+     '''
+     #     return np.transpose(self.grad_grad_B,(1,2,3,0))
+     t = self.tangent_cylindrical
+     n = self.normal_cylindrical
+     b = self.binormal_cylindrical
+     E = np.stack([n, b, t], axis=0)
+     grad_grad_B = self.grad_grad_B.transpose(1, 2, 3, 0)
+     grad_grad_B_tensor_cylindrical = np.einsum('ijkq,iqa,jqb,kqc->abcq', grad_grad_B, E, E, E)
+     return grad_grad_B_tensor_cylindrical
 
 def grad_grad_B_tensor_cartesian(self):
-    '''
-    Function to calculate the gradient of of the gradient the magnetic field
-    vector B=(B_x,B_y,B_z) at every point along the axis (hence with nphi points)
-    where x, y and z are the standard cartesian coordinates.
-    '''
-    nablanablaB = self.grad_grad_B_tensor_cylindrical()
+    """
+    Transform the second derivative tensor of the magnetic field from cylindrical to Cartesian coordinates.
+    Shape: (nphi, 3, 3, 3)
+    """
+    grad_grad_B_cyl = self.grad_grad_B_tensor_cylindrical().transpose(3, 0, 1, 2)  # shape (nphi, 3, 3, 3)
     cosphi = np.cos(self.phi)
     sinphi = np.sin(self.phi)
 
-    grad_grad_B_vector_cartesian = np.array([[
-[cosphi**3*nablanablaB[0, 0, 0] - cosphi**2*sinphi*(nablanablaB[0, 0, 1] + 
-      nablanablaB[0, 1, 0] + nablanablaB[1, 0, 0]) + 
-    cosphi*sinphi**2*(nablanablaB[0, 1, 1] + nablanablaB[1, 0, 1] + 
-      nablanablaB[1, 1, 0]) - sinphi**3*nablanablaB[1, 1, 1], 
-   cosphi**3*nablanablaB[0, 0, 1] + cosphi**2*sinphi*(nablanablaB[0, 0, 0] - 
-      nablanablaB[0, 1, 1] - nablanablaB[1, 0, 1]) + sinphi**3*nablanablaB[1, 1, 0] - 
-    cosphi*sinphi**2*(nablanablaB[0, 1, 0] + nablanablaB[1, 0, 0] - 
-      nablanablaB[1, 1, 1]), cosphi**2*nablanablaB[0, 0, 2] - 
-    cosphi*sinphi*(nablanablaB[0, 1, 2] + nablanablaB[1, 0, 2]) + 
-    sinphi**2*nablanablaB[1, 1, 2]], [cosphi**3*nablanablaB[0, 1, 0] + 
-    sinphi**3*nablanablaB[1, 0, 1] + cosphi**2*sinphi*(nablanablaB[0, 0, 0] - 
-      nablanablaB[0, 1, 1] - nablanablaB[1, 1, 0]) - 
-    cosphi*sinphi**2*(nablanablaB[0, 0, 1] + nablanablaB[1, 0, 0] - 
-      nablanablaB[1, 1, 1]), cosphi**3*nablanablaB[0, 1, 1] - 
-    sinphi**3*nablanablaB[1, 0, 0] + cosphi*sinphi**2*(nablanablaB[0, 0, 0] - 
-      nablanablaB[1, 0, 1] - nablanablaB[1, 1, 0]) + 
-    cosphi**2*sinphi*(nablanablaB[0, 0, 1] + nablanablaB[0, 1, 0] - 
-      nablanablaB[1, 1, 1]), cosphi**2*nablanablaB[0, 1, 2] - 
-    sinphi**2*nablanablaB[1, 0, 2] + cosphi*sinphi*(nablanablaB[0, 0, 2] - 
-      nablanablaB[1, 1, 2])], [cosphi**2*nablanablaB[0, 2, 0] - 
-    cosphi*sinphi*(nablanablaB[0, 2, 1] + nablanablaB[1, 2, 0]) + 
-    sinphi**2*nablanablaB[1, 2, 1], cosphi**2*nablanablaB[0, 2, 1] - 
-    sinphi**2*nablanablaB[1, 2, 0] + cosphi*sinphi*(nablanablaB[0, 2, 0] - 
-      nablanablaB[1, 2, 1]), cosphi*nablanablaB[0, 2, 2] - 
-    sinphi*nablanablaB[1, 2, 2]]], 
- [[sinphi**3*nablanablaB[0, 1, 1] + cosphi**3*nablanablaB[1, 0, 0] + 
-    cosphi**2*sinphi*(nablanablaB[0, 0, 0] - nablanablaB[1, 0, 1] - 
-      nablanablaB[1, 1, 0]) - cosphi*sinphi**2*(nablanablaB[0, 0, 1] + 
-      nablanablaB[0, 1, 0] - nablanablaB[1, 1, 1]), -(sinphi**3*nablanablaB[0, 1, 0]) + 
-    cosphi**3*nablanablaB[1, 0, 1] + cosphi*sinphi**2*(nablanablaB[0, 0, 0] - 
-      nablanablaB[0, 1, 1] - nablanablaB[1, 1, 0]) + 
-    cosphi**2*sinphi*(nablanablaB[0, 0, 1] + nablanablaB[1, 0, 0] - 
-      nablanablaB[1, 1, 1]), -(sinphi**2*nablanablaB[0, 1, 2]) + 
-    cosphi**2*nablanablaB[1, 0, 2] + cosphi*sinphi*(nablanablaB[0, 0, 2] - 
-      nablanablaB[1, 1, 2])], [-(sinphi**3*nablanablaB[0, 0, 1]) + 
-    cosphi*sinphi**2*(nablanablaB[0, 0, 0] - nablanablaB[0, 1, 1] - 
-      nablanablaB[1, 0, 1]) + cosphi**3*nablanablaB[1, 1, 0] + 
-    cosphi**2*sinphi*(nablanablaB[0, 1, 0] + nablanablaB[1, 0, 0] - 
-      nablanablaB[1, 1, 1]), sinphi**3*nablanablaB[0, 0, 0] + 
-    cosphi*sinphi**2*(nablanablaB[0, 0, 1] + nablanablaB[0, 1, 0] + 
-      nablanablaB[1, 0, 0]) + cosphi**2*sinphi*(nablanablaB[0, 1, 1] + 
-      nablanablaB[1, 0, 1] + nablanablaB[1, 1, 0]) + cosphi**3*nablanablaB[1, 1, 1], 
-   sinphi**2*nablanablaB[0, 0, 2] + cosphi*sinphi*(nablanablaB[0, 1, 2] + 
-      nablanablaB[1, 0, 2]) + cosphi**2*nablanablaB[1, 1, 2]], 
-  [-(sinphi**2*nablanablaB[0, 2, 1]) + cosphi**2*nablanablaB[1, 2, 0] + 
-    cosphi*sinphi*(nablanablaB[0, 2, 0] - nablanablaB[1, 2, 1]), 
-   sinphi**2*nablanablaB[0, 2, 0] + cosphi*sinphi*(nablanablaB[0, 2, 1] + 
-      nablanablaB[1, 2, 0]) + cosphi**2*nablanablaB[1, 2, 1], 
-   sinphi*nablanablaB[0, 2, 2] + cosphi*nablanablaB[1, 2, 2]]], 
- [[cosphi**2*nablanablaB[2, 0, 0] - cosphi*sinphi*(nablanablaB[2, 0, 1] + 
-      nablanablaB[2, 1, 0]) + sinphi**2*nablanablaB[2, 1, 1], 
-   cosphi**2*nablanablaB[2, 0, 1] - sinphi**2*nablanablaB[2, 1, 0] + 
-    cosphi*sinphi*(nablanablaB[2, 0, 0] - nablanablaB[2, 1, 1]), 
-   cosphi*nablanablaB[2, 0, 2] - sinphi*nablanablaB[2, 1, 2]], 
-  [-(sinphi**2*nablanablaB[2, 0, 1]) + cosphi**2*nablanablaB[2, 1, 0] + 
-    cosphi*sinphi*(nablanablaB[2, 0, 0] - nablanablaB[2, 1, 1]), 
-   sinphi**2*nablanablaB[2, 0, 0] + cosphi*sinphi*(nablanablaB[2, 0, 1] + 
-      nablanablaB[2, 1, 0]) + cosphi**2*nablanablaB[2, 1, 1], 
-   sinphi*nablanablaB[2, 0, 2] + cosphi*nablanablaB[2, 1, 2]], 
-  [cosphi*nablanablaB[2, 2, 0] - sinphi*nablanablaB[2, 2, 1], 
-   sinphi*nablanablaB[2, 2, 0] + cosphi*nablanablaB[2, 2, 1], nablanablaB[2, 2, 2]]
-      ]])
+    # Rotation matrix R from cylindrical (R, φ, Z) to Cartesian (x, y, z)
+    R = np.array([
+        [cosphi, -sinphi, np.zeros_like(cosphi)],
+        [sinphi,  cosphi, np.zeros_like(cosphi)],
+        [np.zeros_like(cosphi), np.zeros_like(cosphi), np.ones_like(cosphi)],
+    ])  # shape (3, 3, nphi)
 
-    return grad_grad_B_vector_cartesian
+    # Transpose to shape (nphi, 3, 3)
+    R = np.transpose(R, (2, 0, 1))
+
+    # Apply tensor transformation: R[i,a] * R[j,b] * R[k,c] * T[a,b,c]
+    T_cartesian = np.einsum('pia,pjb,pkc,pabc->pijk',
+                            R, R, R, grad_grad_B_cyl)
+
+    return T_cartesian.transpose(1,2,3,0)  # shape (nphi, 3, 3, 3)

--- a/qsc/tests/test_grad_B_tensor.py
+++ b/qsc/tests/test_grad_B_tensor.py
@@ -121,6 +121,96 @@ class GradGradBTensorTests(unittest.TestCase):
                         np.testing.assert_allclose(s.grad_grad_B_alt[:,0,2,0], np.full(nphi, val), rtol=rtol, atol=atol)
                         np.testing.assert_allclose(s.grad_grad_B_alt[:,0,0,2], np.full(nphi, val), rtol=rtol, atol=atol)
                         
+class DirectionalDerivativeTests(unittest.TestCase):
+    def test_axisymmetry(self):
+        """
+        Test that the grad grad B tensor is correct for an axisymmetric vacuum field
+        """
+        B0_vals = [0.9, 1.1]
+        R0_vals = [0.85, 1.0, 1.2]
+        nphi_vals = [3, 5, 7, 9, 11]
+        etabar_vals = [0.55, 0.65, 0.95, 1.0, 1.09, 1.3, 1.4]
+        index = 0
+        for sG in [-1, 1]:
+            for spsi in [-1, 1]:
+                for nfp in range(1, 4):
+                    for j in range(3):
+                        """
+                        R0 = np.random.rand() * 2 + 0.3
+                        B0 = np.random.rand() * 2 + 0.3
+                        nphi = int(np.random.rand() * 10 + 3)
+                        etabar = (np.random.rand() - 0.5) * 4
+                        """
+                        # Try many combinations of values, in a deterministic way:
+                        R0 = R0_vals[np.mod(index, len(R0_vals))]
+                        B0 = B0_vals[np.mod(index, len(B0_vals))]
+                        nphi = nphi_vals[np.mod(index, len(nphi_vals))]
+                        etabar = etabar_vals[np.mod(index, len(etabar_vals))]
+                        index += 1
+                        
+                        s = Qsc(rc=[R0], zs=[0], nfp=nfp, nphi=nphi, sG=sG, \
+                                   spsi=spsi, B0=B0, etabar=etabar, I2=1.e-8, order='r2')
+                        # The O(r^2) solve fails if iota is exactly 0,
+                        # so above we set a tiny nonzero current to
+                        # create a tiny nonzero iota.
+                        if np.mod(nphi, 2) == 0:
+                            nphi += 1
+
+                        s.calculate_grad_grad_B_tensor(two_ways=True)
+                        # Check all components other than {tnn, ntn, nnt, ttt}. These should be 0.
+                        rtol = 1e-6
+                        atol = 1e-6
+                        
+                        # this test checks that the derivatives B'(\phi) and B''(\phi) 
+                        # when calculated by from the gradB and gradgradB tensors are correct
+                        axis_B0 = s.Bfield_cartesian(r=0, theta=0.)
+                        axis_B1 = s.grad_B_tensor_cartesian()
+                        axis_B2 = s.grad_grad_B_tensor_cartesian()
+                        
+                        from simsopt.geo import CurveRZFourier
+                        nfp=s.nfp
+                        G0 = CurveRZFourier(np.linspace(0, 1/nfp, s.phi.size, endpoint=False), s.rc.size-1, nfp, True)
+                        G0.rc[0] = R0
+                        G0.x = G0.get_dofs()
+
+                        dG0_dphi = G0.gammadash()
+                        d2G0_dphi2 = G0.gammadashdash()
+                        
+                        ds_dphi = np.linalg.norm(dG0_dphi, axis=1)
+                        d2s_dphi2 = np.sum(dG0_dphi*d2G0_dphi2)/ds_dphi[:, None]
+                        
+                        T, N, B = G0.frenet_frame()
+                        kappa = G0.kappa()
+                        dkappa_dphi = G0.kappadash()
+                        dkappa_ds = dkappa_dphi * (1/ds_dphi)
+                        torsion = G0.torsion()
+                        
+                        dT_ds = kappa[:, None] * N
+                        dN_ds = -kappa[:, None] * T + torsion[:, None]*B
+                        d2T_ds2 = dkappa_ds[:, None] * N + dN_ds*kappa[:, None]
+                        
+                        dT_dphi = dT_ds * ds_dphi[:, None]
+                        d2T_dphi2 = d2T_ds2*ds_dphi[:, None]**2 + d2s_dphi2*dT_ds
+                        
+                        Bexact = np.transpose(axis_B0, axes=(1, 0))
+                        Bqsc = sG*B0*T
+                        
+                        #check B(\phi)
+                        np.testing.assert_allclose(Bexact, Bqsc, rtol=rtol, atol=atol)
+                        
+                        dG0_dphi = np.transpose(dG0_dphi, axes=(1, 0))
+                        dBqsc_dphi = np.einsum('ijk,ik->jk', axis_B1, dG0_dphi)
+                        dBexact_dphi = sG*B0*dT_dphi
+                        dBexact_dphi = np.transpose(dBexact_dphi, axes=(1, 0))
+                        #check B'(\phi)
+                        np.testing.assert_allclose(dBexact_dphi, dBqsc_dphi, rtol=rtol, atol=atol)
+                        
+                        d2G0_dphi2 = np.transpose(d2G0_dphi2, axes=(1, 0))
+                        d2Bqsc_dphi2 = np.einsum('ijkl,jl,kl->il', axis_B2, dG0_dphi, dG0_dphi)+np.einsum('ijl,jl->il', axis_B1, d2G0_dphi2)
+                        d2Bexact_dphi2 = sG*B0*d2T_dphi2
+                        d2Bexact_dphi2 = np.transpose(d2Bexact_dphi2, axes=(1, 0))
+                        #check B''(\phi)
+                        np.testing.assert_allclose(d2Bexact_dphi2, d2Bqsc_dphi2, rtol=rtol, atol=atol)
 
 class CylindricalCartesianTensorsTests(unittest.TestCase):
 

--- a/qsc/tests/test_grad_B_tensor.py
+++ b/qsc/tests/test_grad_B_tensor.py
@@ -122,6 +122,24 @@ class GradGradBTensorTests(unittest.TestCase):
                         np.testing.assert_allclose(s.grad_grad_B_alt[:,0,0,2], np.full(nphi, val), rtol=rtol, atol=atol)
                         
 class DirectionalDerivativeTests(unittest.TestCase):
+    """
+    This test computes the B(\phi), B'(\phi), and B''(\phi) on the magnetic
+    axis in two ways, where \phi is the standard cylindrical angle.  
+    
+    The first way uses the fact that B(\phi) = sG*B0*T(\phi), where T(\phi) is 
+    the tangent vector of the Frenet frame associated to the magnetic axis. Since
+    we have analytical expressions for the Frenet frame, we can differentiate them
+    with respect to \phi.
+
+    The second way relies on the gradB, and gradgradB tensors in pyqsc associated
+    to the NAE.  We know that hatB(\phi) = B(\Gamma(\phi)) where Bhat is the magnetic
+    field B evaluated on the magnetic axis, given by \Gamma(\phi).  Differentiating
+    this expression with respect to \phi and applying the chain rule, we obtain
+    a formula for hatB(\phi) that depends on derivative tensors of B.
+
+    With these two independent formulas for B, B', and B'', we can verify that
+    the two results are the same.
+    """
     def test_B_Bprime_Bprimeprime(self):
         rtol = 1e-6
         atol = 1e-10

--- a/qsc/tests/test_grad_B_tensor.py
+++ b/qsc/tests/test_grad_B_tensor.py
@@ -141,8 +141,8 @@ class DirectionalDerivativeTests(unittest.TestCase):
     the two results are the same.
     """
     def test_B_Bprime_Bprimeprime(self):
-        rtol = 1e-6
-        atol = 1e-10
+        rtol = 1e-8
+        atol = 1e-8
         
         np.random.seed(0)
         for sG in [-1, 1]:

--- a/qsc/tests/test_grad_B_tensor.py
+++ b/qsc/tests/test_grad_B_tensor.py
@@ -122,95 +122,71 @@ class GradGradBTensorTests(unittest.TestCase):
                         np.testing.assert_allclose(s.grad_grad_B_alt[:,0,0,2], np.full(nphi, val), rtol=rtol, atol=atol)
                         
 class DirectionalDerivativeTests(unittest.TestCase):
-    def test_axisymmetry(self):
-        """
-        Test that the grad grad B tensor is correct for an axisymmetric vacuum field
-        """
-        B0_vals = [0.9, 1.1]
-        R0_vals = [0.85, 1.0, 1.2]
-        nphi_vals = [3, 5, 7, 9, 11]
-        etabar_vals = [0.55, 0.65, 0.95, 1.0, 1.09, 1.3, 1.4]
-        index = 0
+    def test_B_Bprime_Bprimeprime(self):
+        rtol = 1e-6
+        atol = 1e-10
+        
+        np.random.seed(0)
         for sG in [-1, 1]:
             for spsi in [-1, 1]:
-                for nfp in range(1, 4):
-                    for j in range(3):
-                        """
-                        R0 = np.random.rand() * 2 + 0.3
-                        B0 = np.random.rand() * 2 + 0.3
-                        nphi = int(np.random.rand() * 10 + 3)
-                        etabar = (np.random.rand() - 0.5) * 4
-                        """
-                        # Try many combinations of values, in a deterministic way:
-                        R0 = R0_vals[np.mod(index, len(R0_vals))]
-                        B0 = B0_vals[np.mod(index, len(B0_vals))]
-                        nphi = nphi_vals[np.mod(index, len(nphi_vals))]
-                        etabar = etabar_vals[np.mod(index, len(etabar_vals))]
-                        index += 1
-                        
-                        s = Qsc(rc=[R0], zs=[0], nfp=nfp, nphi=nphi, sG=sG, \
-                                   spsi=spsi, B0=B0, etabar=etabar, I2=1.e-8, order='r2')
-                        # The O(r^2) solve fails if iota is exactly 0,
-                        # so above we set a tiny nonzero current to
-                        # create a tiny nonzero iota.
-                        if np.mod(nphi, 2) == 0:
-                            nphi += 1
+                for config in [1, 2, 3, 4, 5]:
+                    print(sG, spsi, config)
+                    B0 = np.random.rand() * 0.4 + 0.8
+                    nphi = int(np.random.rand() * 50 + 61)
+                    s = Qsc.from_paper(config, sG=sG, spsi=spsi, B0=B0, nphi=nphi)
+                    s.calculate()
 
-                        s.calculate_grad_grad_B_tensor(two_ways=True)
-                        # Check all components other than {tnn, ntn, nnt, ttt}. These should be 0.
-                        rtol = 1e-6
-                        atol = 1e-6
-                        
-                        # this test checks that the derivatives B'(\phi) and B''(\phi) 
-                        # when calculated by from the gradB and gradgradB tensors are correct
-                        axis_B0 = s.Bfield_cartesian(r=0, theta=0.)
-                        axis_B1 = s.grad_B_tensor_cartesian()
-                        axis_B2 = s.grad_grad_B_tensor_cartesian()
-                        
-                        from simsopt.geo import CurveRZFourier
-                        nfp=s.nfp
-                        G0 = CurveRZFourier(np.linspace(0, 1/nfp, s.phi.size, endpoint=False), s.rc.size-1, nfp, True)
-                        G0.rc[0] = R0
-                        G0.x = G0.get_dofs()
-
-                        dG0_dphi = G0.gammadash()
-                        d2G0_dphi2 = G0.gammadashdash()
-                        
-                        ds_dphi = np.linalg.norm(dG0_dphi, axis=1)
-                        d2s_dphi2 = np.sum(dG0_dphi*d2G0_dphi2)/ds_dphi[:, None]
-                        
-                        T, N, B = G0.frenet_frame()
-                        kappa = G0.kappa()
-                        dkappa_dphi = G0.kappadash()
-                        dkappa_ds = dkappa_dphi * (1/ds_dphi)
-                        torsion = G0.torsion()
-                        
-                        dT_ds = kappa[:, None] * N
-                        dN_ds = -kappa[:, None] * T + torsion[:, None]*B
-                        d2T_ds2 = dkappa_ds[:, None] * N + dN_ds*kappa[:, None]
-                        
-                        dT_dphi = dT_ds * ds_dphi[:, None]
-                        d2T_dphi2 = d2T_ds2*ds_dphi[:, None]**2 + d2s_dphi2*dT_ds
-                        
-                        Bexact = np.transpose(axis_B0, axes=(1, 0))
-                        Bqsc = sG*B0*T
-                        
-                        #check B(\phi)
-                        np.testing.assert_allclose(Bexact, Bqsc, rtol=rtol, atol=atol)
-                        
-                        dG0_dphi = np.transpose(dG0_dphi, axes=(1, 0))
-                        dBqsc_dphi = np.einsum('ijk,ik->jk', axis_B1, dG0_dphi)
-                        dBexact_dphi = sG*B0*dT_dphi
-                        dBexact_dphi = np.transpose(dBexact_dphi, axes=(1, 0))
-                        #check B'(\phi)
-                        np.testing.assert_allclose(dBexact_dphi, dBqsc_dphi, rtol=rtol, atol=atol)
-                        
-                        d2G0_dphi2 = np.transpose(d2G0_dphi2, axes=(1, 0))
-                        d2Bqsc_dphi2 = np.einsum('ijkl,jl,kl->il', axis_B2, dG0_dphi, dG0_dphi)+np.einsum('ijl,jl->il', axis_B1, d2G0_dphi2)
-                        d2Bexact_dphi2 = sG*B0*d2T_dphi2
-                        d2Bexact_dphi2 = np.transpose(d2Bexact_dphi2, axes=(1, 0))
-                        #check B''(\phi)
-                        np.testing.assert_allclose(d2Bexact_dphi2, d2Bqsc_dphi2, rtol=rtol, atol=atol)
+                    # this test checks that the derivatives B'(\phi) and B''(\phi) 
+                    # when calculated by from the gradB and gradgradB tensors are correct
+                    axis_B0 = s.Bfield_cartesian(r=0, theta=0.)
+                    axis_B1 = s.grad_B_tensor_cartesian()
+                    axis_B2 = s.grad_grad_B_tensor_cartesian()
+                    
+                    from simsopt.geo import CurveRZFourier
+                    nfp=s.nfp
+                    G0 = CurveRZFourier(np.linspace(0, 1/nfp, s.phi.size, endpoint=False), s.rc.size-1, nfp, True)
+                    G0.rc[:] = s.rc[:]
+                    G0.zs[:] = s.zs[1:]
+                    G0.x = G0.get_dofs()
+                    
+                    dG0_dphi = G0.gammadash()
+                    d2G0_dphi2 = G0.gammadashdash()
+                    
+                    ds_dphi = np.linalg.norm(dG0_dphi, axis=1)
+                    d2s_dphi2 = np.sum(dG0_dphi*d2G0_dphi2, axis=1)/ds_dphi
+                    
+                    T, N, B = G0.frenet_frame()
+                    kappa = G0.kappa()
+                    dkappa_dphi = G0.kappadash()
+                    dkappa_ds = dkappa_dphi * (1/ds_dphi)
+                    torsion = G0.torsion()
+                    
+                    dT_ds = kappa[:, None] * N
+                    dN_ds = -kappa[:, None] * T + torsion[:, None]*B
+                    d2T_ds2 = dkappa_ds[:, None] * N + dN_ds*kappa[:, None]
+                    
+                    dT_dphi = dT_ds * ds_dphi[:, None]
+                    d2T_dphi2 = d2T_ds2*ds_dphi[:, None]**2 + d2s_dphi2[:, None]*dT_ds
+                    
+                    Bexact = np.transpose(axis_B0, axes=(1, 0))
+                    Bqsc = sG*B0*T
+                    
+                    #check B(\phi)
+                    np.testing.assert_allclose(Bexact, Bqsc, rtol=rtol, atol=atol)
+                    
+                    dG0_dphi = np.transpose(dG0_dphi, axes=(1, 0))
+                    dBqsc_dphi = np.einsum('ijk,ik->jk', axis_B1, dG0_dphi)
+                    dBexact_dphi = sG*B0*dT_dphi
+                    dBexact_dphi = np.transpose(dBexact_dphi, axes=(1, 0))
+                    #check B'(\phi)
+                    np.testing.assert_allclose(dBexact_dphi, dBqsc_dphi, rtol=rtol, atol=atol)
+                    
+                    d2G0_dphi2 = np.transpose(d2G0_dphi2, axes=(1, 0))
+                    d2Bqsc_dphi2 = np.einsum('ijkl,il,jl->kl', axis_B2, dG0_dphi, dG0_dphi)+np.einsum('ijl,jl->il', axis_B1, d2G0_dphi2)
+                    d2Bexact_dphi2 = sG*B0*d2T_dphi2
+                    d2Bexact_dphi2 = np.transpose(d2Bexact_dphi2, axes=(1, 0))
+                    #check B''(\phi)
+                    np.testing.assert_allclose(d2Bexact_dphi2, d2Bqsc_dphi2, rtol=rtol, atol=atol)
 
 class CylindricalCartesianTensorsTests(unittest.TestCase):
 


### PR DESCRIPTION
 I noticed that the conversion of the gradgradB tensor from Frenet to cylindrical does not appear correct in the current version of the code.  This PR attempts to fix the conversion of the gradgradB tensor from Frenet to cylindrical, and as well cylindrical to Cartesian coordinates.  We propose a fix in this PR with @rogeriojorge and @mishapadidar.

The unit test that I wrote depends on simsopt for convenience.  It would take some work to remove this dependence.

I have also added an additional unit test as described here:
![image](https://github.com/user-attachments/assets/df8f5d37-f855-4cce-9d74-37419c12aa65)
